### PR TITLE
preserve cursor position when invoking 'navigateToFile'

### DIFF
--- a/R/stubs.R
+++ b/R/stubs.R
@@ -22,7 +22,7 @@ sourceMarkers <- function(name, markers, basePath = NULL,
 }
 
 #' @export
-navigateToFile <- function(file, line = 1L, column = 1L) {
+navigateToFile <- function(file, line = -1L, column = -1L) {
   callFun("navigateToFile", file, as.integer(line), as.integer(column))
 }
 

--- a/man/navigateToFile.Rd
+++ b/man/navigateToFile.Rd
@@ -10,7 +10,7 @@ Open a file in RStudio, optionally at a specified location.
 The \code{navigateToFile} function was added in version 0.99.719 of RStudio.
 }
 \usage{
-navigateToFile(file, line = 1L, column = 1L) 
+navigateToFile(file, line = -1L, column = -1L)
 }
 
 \arguments{
@@ -20,7 +20,7 @@ navigateToFile(file, line = 1L, column = 1L)
 }
 
 \details{
-The \code{navigateToFile} opens a file in RStudio. If the file is already open, its tab or window is activated. 
+The \code{navigateToFile} opens a file in RStudio. If the file is already open, its tab or window is activated.
 
 Once the file is open, the cursor is moved to the specified location.
 


### PR DESCRIPTION
This PR (alongside newer versions of the RStudio IDE) will allow users to request that the IDE preserve the previous cursor position when navigating to a file.

https://github.com/rstudio/rstudio/pull/1305

Note that the current behavior is preserved when running against older version of the IDE; that is, attempting to navigate to position `[-1, -1]` works the same as `[1, 1]` because RStudio transforms the positions to be valid behind the scenes.