### PR TITLE
Actually fix getSourceEditorContext()

### DIFF
--- a/R/document-methods.R
+++ b/R/document-methods.R
@@ -213,12 +213,11 @@ primary_selection.document_selection <- function(x, ...) {
 getDocumentContext <- function(fn) {
   context <- callFun(fn)
 
-  if (is.character(context$path))
-    Encoding(context$path) <- "UTF-8"
-
-  if (is.character(context$contents))
-    Encoding(context$contents) <- "UTF-8"
-
+  if (is.null(context)) return(NULL)
+  
+  Encoding(context$path) <- "UTF-8"
+  Encoding(context$contents) <- "UTF-8"
   context$selection <- as.document_selection(context$selection)
+  
   structure(context, class = "document_context")
 }


### PR DESCRIPTION
Makes rstudioapi::getSourceEditorContext() return NULL if there is no open source editor pane.
The previous fix just changed the error message (now the failing line is as.document_selection(NULL) throwing Error: 'x' should be a list of {range, text} pairs)