### PR TITLE
Change default showPrompt field value to empty string

### DIFF
--- a/R/dialogs.R
+++ b/R/dialogs.R
@@ -61,7 +61,7 @@ updateDialog <- function(...) {
 #' @note The \code{showPrompt} function was added in version 1.1.67 of RStudio.
 #'
 #' @export
-showPrompt <- function(title, message, default = NULL) {
+showPrompt <- function(title, message, default = "") {
   callFun("showPrompt", title, message, default)
 }
 


### PR DESCRIPTION
If the default optional arg isn't specified, by default the prompt field contains the string "NA" which is unsightly. This fix changes default content of the prompt field is an empty string.