### PR TITLE
Fix getActiveProject() for non-ASCII file paths

### DIFF
--- a/R/stubs.R
+++ b/R/stubs.R
@@ -35,6 +35,11 @@ askForPassword <- function(prompt = "Please enter your password") {
 #' @export
 getActiveProject <- function() {
   path <- callFun("getActiveProject")
+  
+  # path is NULL iff there is no open project
+  if (is.null(path)) return(path)
+  
+  # ... otherwise path is UTF-8 encoded
   Encoding(path) <- "UTF-8"
   path
 }

--- a/R/stubs.R
+++ b/R/stubs.R
@@ -31,9 +31,12 @@ askForPassword <- function(prompt = "Please enter your password") {
   callFun("askForPassword", prompt)
 }
 
+#' Get Path to Active RStudio Project
 #' @export
 getActiveProject <- function() {
-  callFun("getActiveProject")
+  path <- callFun("getActiveProject")
+  Encoding(path) <- "UTF-8"
+  path
 }
 
 #' Save Active RStudio Plot as an Image


### PR DESCRIPTION
On Windows paths containing non-ASCII characters will be returned in UTF-8 encoding but with implicit Encoding(...) of native.
Thus, the returned path is mis-encoded.