### PR TITLE
Clean up Roxygen comments for getThemeInfo

### DIFF
--- a/R/themes.R
+++ b/R/themes.R
@@ -5,9 +5,6 @@
 #' applied to the main user interface in RStudio and \code{dark} when
 #' the user interface is optimized for dark themes.
 #'
-#' RStudio 1.2.553 adds support for \code{background} and \code{color}
-#' as the primary colors used under the code editor.
-#'
 #' @export
 getThemeInfo <- function() {
   callFun("getThemeInfo")

--- a/man/getThemeInfo.Rd
+++ b/man/getThemeInfo.Rd
@@ -12,7 +12,3 @@ the theme used under the code editor, \code{global} as the global theme
 applied to the main user interface in RStudio and \code{dark} when
 the user interface is optimized for dark themes.
 }
-\details{
-RStudio 1.2.553 adds support for \code{background} and \code{color}
-as the primary colors used under the code editor.
-}


### PR DESCRIPTION
We removed `color` and `background` from the return value in PR 3608 of https://github.com/rstudio/rstudio. This PR updates the documentation to match.