### PR TITLE
Download and/or convert theme as appropriate

### DIFF
--- a/R/themes.R
+++ b/R/themes.R
@@ -48,8 +48,7 @@ addTheme <- function(themePath,
   # If the path appears to be a URL, download it.
   if (grepl("^https?:", themePath)) {
     # Give the downloaded filename the same name and extension as the original.
-    parts <- strsplit(themePath, "/", fixed = TRUE)[[1]]
-    path <- file.path(tempdir(), parts[length(parts)])
+    path <- file.path(tempdir(), basename(themePath))
     if (file.exists(path)) {
       # It's unlikely that the theme file will exist in the temp dir, but move it out
       # of the way if it does.

--- a/R/themes.R
+++ b/R/themes.R
@@ -14,7 +14,8 @@ getThemeInfo <- function() {
 #'
 #' Adds a custom editor theme to RStudio and returns the name of the newly added theme.
 #'
-#' @param themePath      A full or relative path to the \code{rstheme} file to be added.
+#' @param themePath      A full or relative path or URL to an \code{rstheme} or \code{tmtheme} to be
+#'                       added.
 #' @param apply          Whether to immediately apply the newly added theme. Setting this to
 #'                       \code{TRUE} has the same impact as running
 #'                       \code{{ rstudioapi::addTheme(<themePath>); rstudioapi::applyTheme(<themeName>) }}.\cr
@@ -35,7 +36,37 @@ addTheme <- function(themePath,
                      force = FALSE,
                      globally = FALSE)
 {
-  callFun("addTheme", themePath, apply, force, globally)
+  path <- themePath
+
+  # Ensure path looks like something we can use
+  ext <- tolower(tools::file_ext(path))
+  if (!identical(ext, "rstheme") && !identical(ext, "tmtheme")) {
+    stop("Invalid path ", path, ". ",
+         "Please supply a path or URL to an .rstheme or .tmtheme file to add.")
+  }
+
+  # If the path appears to be a URL, download it.
+  if (grepl("^https?:", themePath)) {
+    # Give the downloaded filename the same name and extension as the original.
+    parts <- strsplit(themePath, "/", fixed = TRUE)[[1]]
+    path <- file.path(tempdir(), parts[length(parts)])
+    if (file.exists(path)) {
+      # It's unlikely that the theme file will exist in the temp dir, but move it out
+      # of the way if it does.
+      unlink(path)
+    }
+
+    # Perform the download
+    download.file(themePath, path)
+  }
+
+  if (identical(ext, "tmtheme")) {
+    # needs conversion first
+    convertTheme(path, add = TRUE, apply = apply, force = force, globally = globally)
+  } else if (identical(ext, "rstheme")) {
+    # no conversion necessary
+    callFun("addTheme", path, apply, force, globally)
+  }
 }
 
 #' Apply an Editor Theme to RStudio

--- a/man/addTheme.Rd
+++ b/man/addTheme.Rd
@@ -7,7 +7,8 @@
 addTheme(themePath, apply = FALSE, force = FALSE, globally = FALSE)
 }
 \arguments{
-\item{themePath}{A full or relative path to the \code{rstheme} file to be added.}
+\item{themePath}{A full or relative path or URL to an \code{rstheme} or \code{tmtheme} to be
+added.}
 
 \item{apply}{Whether to immediately apply the newly added theme. Setting this to
 \code{TRUE} has the same impact as running


### PR DESCRIPTION
This is a small change motivated by theme installation instructions beginning to appear in the wild, e.g.:

https://github.com/gadenbuie/yule-rstudio

https://github.com/batpigandme/night-owlish

Ideally the "install and apply my theme" code snippet featured in these repos would be a single line of R code. This change makes that possible by adding some logic to the `addTheme` API wrapper:

1. If the theme path given looks like a URL, it's downloaded first.
2. If the theme path given looks like a .tmtheme, it's converted first.

After the change, you can download, install, and apply a theme in a single step:

    rstudioapi::addTheme("https://raw.githubusercontent.com/gadenbuie/yule-rstudio/master/Yule-RStudio.rstheme", apply = TRUE)