### PR TITLE
Add name argument to jobRunScript

### DIFF
--- a/R/jobs.R
+++ b/R/jobs.R
@@ -155,6 +155,7 @@ jobAddOutput <- function(job, output, error = FALSE) {
 jobRunScript <- function(path, name = NULL, encoding = "unknown", workingDir = NULL,
                          importEnv = FALSE, exportEnv = "") {
     callFun("runScriptJob", path       = path,
+                            name       = name,
                             encoding   = encoding,
                             workingDir = workingDir,
                             importEnv  = importEnv,

--- a/R/jobs.R
+++ b/R/jobs.R
@@ -140,6 +140,8 @@ jobAddOutput <- function(job, output, error = FALSE) {
 #' Starts an R script as a background job.
 #'
 #' @param path The path to the R script to be run.
+#' @param name A name for the background job. When \code{NULL} (the default), the filename of the
+#'   script is used as the job name.
 #' @param encoding The text encoding of the script, if known.
 #' @param workingDir The working directory in which to run the job. When \code{NULL} (the default),
 #'   the parent directory of the R script is used.
@@ -150,8 +152,8 @@ jobAddOutput <- function(job, output, error = FALSE) {
 #'
 #' @family jobs
 #' @export
-jobRunScript <- function(path, encoding = "unknown", workingDir = NULL, importEnv = FALSE,
-                         exportEnv = "") {
+jobRunScript <- function(path, name = NULL, encoding = "unknown", workingDir = NULL,
+                         importEnv = FALSE, exportEnv = "") {
     callFun("runScriptJob", path       = path,
                             encoding   = encoding,
                             workingDir = workingDir,

--- a/man/jobRunScript.Rd
+++ b/man/jobRunScript.Rd
@@ -4,11 +4,14 @@
 \alias{jobRunScript}
 \title{Run R Script As Job}
 \usage{
-jobRunScript(path, encoding = "unknown", workingDir = NULL,
-  importEnv = FALSE, exportEnv = "")
+jobRunScript(path, name = NULL, encoding = "unknown",
+  workingDir = NULL, importEnv = FALSE, exportEnv = "")
 }
 \arguments{
 \item{path}{The path to the R script to be run.}
+
+\item{name}{A name for the background job. When \code{NULL} (the default), the filename of the
+script is used as the job name.}
 
 \item{encoding}{The text encoding of the script, if known.}
 


### PR DESCRIPTION
This simple change makes it possible to supply a name when running a script as a background job.

See https://github.com/rstudio/rstudio/issues/4176 for discussion.