### PR TITLE
URL decode theme filenames

### DIFF
--- a/R/themes.R
+++ b/R/themes.R
@@ -57,7 +57,7 @@ addTheme <- function(themePath,
   # If the path appears to be a URL, download it.
   if (grepl("^https?:", themePath)) {
     # Give the downloaded filename the same name and extension as the original.
-    path <- file.path(tempdir(), basename(themePath))
+    path <- file.path(tempdir(), utils::URLdecode(basename(themePath)))
     if (file.exists(path)) {
       # It's unlikely that the theme file will exist in the temp dir, but move it out
       # of the way if it does.


### PR DESCRIPTION
Currently, if you add a theme via URL, its filename on disk appears exactly as it did in the URL; in other words, you are liable to end up with filenames like "My%20Theme.rstheme". 

This change URL-decodes the theme filename before transforming into a path on disk.