### PR TITLE
allow rstudioapi to communicate with RStudio from child procs

### DIFF
--- a/R/code.R
+++ b/R/code.R
@@ -9,7 +9,12 @@
 #' rstudioapi::isAvailable()
 #' \dontrun{rstudioapi::verifyAvailable()}
 isAvailable <- function(version_needed = NULL) {
+
+  if (isChildProcess())
+    return(callRemote(sys.call(), parent.frame()))
+
   identical(.Platform$GUI, "RStudio") && version_ok(version_needed)
+  
 }
 
 version_ok <- function(version = NULL) {
@@ -60,8 +65,11 @@ getVersion <- function() {
 #'   rstudioapi::callFun("versionInfo")
 #' }
 callFun <- function(fname, ...) {
-  verifyAvailable()
   
+  if (isChildProcess())
+    return(callRemote(sys.call(), parent.frame()))
+  
+  verifyAvailable()
   if (usingTools())
     found <- exists(toolsName(fname), envir = toolsEnv(), mode = "function")
   else

--- a/R/code.R
+++ b/R/code.R
@@ -1,16 +1,23 @@
 #' Check if RStudio is running.
 #' 
-#' @return \code{isAvailable} a boolean; \code{verifyAvailable} an error message
-#'   if RStudio is not running
 #' @param version_needed An optional version specification. If supplied, 
 #'   ensures that RStudio is at least that version.
+#'   
+#' @param child_ok Boolean; check if the current R process is a child
+#'   process of the main RStudio session? This can be useful for e.g. RStudio
+#'   Jobs, where you'd like to communicate back with the main R session from
+#'   a child process through `rstudioapi`.
+#'
+#' @return \code{isAvailable} a boolean; \code{verifyAvailable} an error message
+#'   if RStudio is not running
+#'   
 #' @export
 #' @examples
 #' rstudioapi::isAvailable()
 #' \dontrun{rstudioapi::verifyAvailable()}
-isAvailable <- function(version_needed = NULL) {
+isAvailable <- function(version_needed = NULL, child_ok = FALSE) {
 
-  if (isChildProcess())
+  if (child_ok && isChildProcess())
     return(callRemote(sys.call(), parent.frame()))
 
   identical(.Platform$GUI, "RStudio") && version_ok(version_needed)

--- a/R/remote.R
+++ b/R/remote.R
@@ -8,7 +8,8 @@ callRemote <- function(call, frame) {
   # check for active request / response
   request  <- Sys.getenv("RSTUDIOAPI_IPC_REQUESTS_FILE", unset = NA)
   response <- Sys.getenv("RSTUDIOAPI_IPC_RESPONSE_FILE", unset = NA)
-  if (is.na(request) || is.na(response))
+  secret   <- Sys.getenv("RSTUDIOAPI_IPC_SHARED_SECRET", unset = NA)
+  if (is.na(request) || is.na(response) || is.na(secret))
     stop("internal error: callFunRemote() called without remote connection")
 
   attr(call, "srcref") <- NULL
@@ -22,8 +23,9 @@ callRemote <- function(call, frame) {
     call[[i]] <- eval(call[[i]], envir = frame)
 
   # write to tempfile and rename, to ensure atomicity
+  data <- list(secret = secret, call = call)
   tmp <- tempfile(tmpdir = dirname(request))
-  saveRDS(call, file = tmp)
+  saveRDS(data, file = tmp)
   file.rename(tmp, request)
 
   # loop until response is ready (poll)

--- a/R/remote.R
+++ b/R/remote.R
@@ -1,0 +1,56 @@
+
+isChildProcess <- function() {
+  !is.na(Sys.getenv("RSTUDIOAPI_IPC_REQUESTS_FILE", unset = NA))
+}
+
+callRemote <- function(call, frame) {
+
+  # check for active request / response
+  request  <- Sys.getenv("RSTUDIOAPI_IPC_REQUESTS_FILE", unset = NA)
+  response <- Sys.getenv("RSTUDIOAPI_IPC_RESPONSE_FILE", unset = NA)
+  if (is.na(request) || is.na(response))
+    stop("internal error: callFunRemote() called without remote connection")
+
+  attr(call, "srcref") <- NULL
+
+  # ensure rstudioapi functions get appropriate prefix
+  if (is.name(call[[1L]]))
+    call[[1L]] <- call("::", as.name("rstudioapi"), call[[1L]])
+
+  # ensure arguments are evaluated before sending request
+  for (i in seq_along(call)[-1L])
+    call[[i]] <- eval(call[[i]], envir = frame)
+
+  # write to tempfile and rename, to ensure atomicity
+  tmp <- tempfile(tmpdir = dirname(request))
+  saveRDS(call, file = tmp)
+  file.rename(tmp, request)
+
+  # loop until response is ready (poll)
+  # in theory we'd just do a blocking read but there isn't really a good
+  # way to do this in a cross-platform way without additional dependencies
+  now <- Sys.time()
+  repeat {
+
+    # check for response
+    if (file.exists(response))
+      break
+
+    # check for lack of response
+    diff <- difftime(Sys.time(), now, units = "secs")
+    if (diff > 10)
+      stop("RStudio did not respond to rstudioapi IPC request")
+
+    # wait a bit
+    Sys.sleep(0.1)
+
+  }
+
+  # read response
+  response <- readRDS(response)
+  if (inherits(response, "error"))
+    stop(response)
+
+  response
+
+}

--- a/man/isAvailable.Rd
+++ b/man/isAvailable.Rd
@@ -5,13 +5,18 @@
 \alias{verifyAvailable}
 \title{Check if RStudio is running.}
 \usage{
-isAvailable(version_needed = NULL)
+isAvailable(version_needed = NULL, child_ok = FALSE)
 
 verifyAvailable(version_needed = NULL)
 }
 \arguments{
 \item{version_needed}{An optional version specification. If supplied,
 ensures that RStudio is at least that version.}
+
+\item{child_ok}{Boolean; check if the current R process is a child
+process of the main RStudio session? This can be useful for e.g. RStudio
+Jobs, where you'd like to communicate back with the main R session from
+a child process through \code{rstudioapi}.}
 }
 \value{
 \code{isAvailable} a boolean; \code{verifyAvailable} an error message

--- a/rstudioapi.Rproj
+++ b/rstudioapi.Rproj
@@ -13,7 +13,6 @@ RnwWeave: Sweave
 LaTeX: pdfLaTeX
 
 AutoAppendNewline: Yes
-StripTrailingWhitespace: Yes
 
 BuildType: Package
 PackageUseDevtools: Yes


### PR DESCRIPTION
Re: https://github.com/rstudio/rstudio/issues/4490.

This PR implements a (somewhat primitive) mechanism for performing IPC with the parent RStudio session. A pair of files are used to transfer 'requests' / 'responses'; the requests made by `rstudioapi` are just serialized R calls that can be evaluated in the main R session, and the responses can later be read after they are written by the parent session.

This PR communicates through plain files for a couple reasons:

1. Since the relationship here is 1-1, and there's no notion of a "queue" of actions, just using a regular file keeps things simple.

2. R's own solutions for this don't appear appropriate: `socketConnection()` are network sockets, and so require a host + port and the host of issues that accompany those. `fifo()` seem like an option, but unfortunately (as far as I can tell) are unreliable on Windows.

3. We could likely consider farming this out to a separate R package that can handle connections like these more gracefully, but given our small requirements list it seems okay to proceed without dependencies and just use plain old files.

4. Exposing the rsession's guts / C routines to child processes is likely to be challenging, so I wanted to avoid that route.

The main downside of this approach is we need to poll the filesystem rather than listen or wait for something like an OS signal, but that seems like it's worth paying given the downsides of other options. (If we found a low-dependency CRAN package that gave us the lower-level connection bits we might instead want to depend on that)