### PR TITLE
need to mark the returned path as UTF-8

### DIFF
--- a/R/stubs.R
+++ b/R/stubs.R
@@ -185,7 +185,9 @@ selectFile <- function(caption = "Select File",
                        filter = "All Files (*)",
                        existing = TRUE)
 {
-  callFun("selectFile", caption, label, path, filter, existing)
+  out <- callFun("selectFile", caption, label, path, filter, existing)
+  Encoding(out) <- "UTF-8"
+  out
 }
 
 #' @name file-dialogs


### PR DESCRIPTION
This is necessary for paths that contain multi-bytes chars on Windows. Otherwise it displays as Garbage.

### Reproduce steps

1. On Windows
1. Run `rstudioapi::selectFile()`
1. Select any file contains multiple-bytes.

You will find garbage letters in the output. After being marked as UTF-8, it becomes correct.

![image](https://user-images.githubusercontent.com/8368933/66697970-bc890e80-ed0c-11e9-9536-0e314d7b19e5.png)

### Should have 

This API calls some functions I believe registered with RStudio, so the root cause may embeded in [RStudioAPI.cpp](https://github.com/rstudio/rstudio/blob/6a7328a4ce6caa10f521a821e2524c9f26445290/src/cpp/session/modules/RStudioAPI.cpp) and the fixes should be made there.




