### PR TITLE
Set default value for navigateToFile

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
 
 * Fixed an issue where remote `rstudioapi` calls would erroneously use
   a previous response in some cases.
+  
+* Allow `navigateToFile` to accept an empty file. This file will default to the file
+  currently in view in the active column.
 
 # rstudioapi 0.11
 

--- a/R/stubs.R
+++ b/R/stubs.R
@@ -22,7 +22,7 @@ sourceMarkers <- function(name, markers, basePath = NULL,
 }
 
 #' @export
-navigateToFile <- function(file, line = -1L, column = -1L) {
+navigateToFile <- function(file = character(0), line = -1L, column = -1L) {
   callFun("navigateToFile", file, as.integer(line), as.integer(column))
 }
 

--- a/man/navigateToFile.Rd
+++ b/man/navigateToFile.Rd
@@ -14,7 +14,7 @@ navigateToFile(file, line = -1L, column = -1L)
 }
 
 \arguments{
-  \item{file}{Path to the file to open)}
+  \item{file}{Optional; Path to the file to open)}
   \item{line}{Optional; integer specifying the line number on which to place the cursor}
   \item{column}{Optional; integer specifying the column number on which to place the cursor}
 }
@@ -22,8 +22,9 @@ navigateToFile(file, line = -1L, column = -1L)
 \details{
 The \code{navigateToFile} opens a file in RStudio. If the file is already open, its tab or window is activated.
 
-Once the file is open, the cursor is moved to the specified location.  If the \code{line}
-and \code{column} arguments are both equal to \code{-1L} (the default), then
+Once the file is open, the cursor is moved to the specified location. If the \code{file}
+argument is empty (the default), then the file is the file currently in view if one exists.
+If the \code{line} and \code{column} arguments are both equal to \code{-1L} (the default), then
 the cursor position in the document that is opened will be preserved.
 
 Note that if your intent is to navigate to a particular function within a file, you can also cause RStudio to navigate there by invoking \code{\link[utils]{View}} on the function, which has the advantage of falling back on deparsing if the file is not available.


### PR DESCRIPTION
This PR updates the code and documentation to add a default value for the `file` argument in `navigateToFile`. When `file` is not passed, the default value passed is an empty character. The IDE interprets an empty file to be the file currently in the user's view.