### PR TITLE
Add moveCursor option to navigateToFile

### DIFF
--- a/R/code.R
+++ b/R/code.R
@@ -85,7 +85,14 @@ callFun <- function(fname, ...) {
     stop("Function ", fname, " not found in RStudio", call. = FALSE)
   
   f <- findFun(fname, mode = "function")
-  f(...)
+  
+  args <- list(...)
+  if (!"..." %in% names(formals(f)))
+  {
+     while (length(args) > length(formals(f)))
+       args <- args[-length(args)]
+  }
+  do.call(f, args)
 }
 
 #' Exists/get for RStudio functions

--- a/R/stubs.R
+++ b/R/stubs.R
@@ -22,8 +22,8 @@ sourceMarkers <- function(name, markers, basePath = NULL,
 }
 
 #' @export
-navigateToFile <- function(file = character(0), line = -1L, column = -1L) {
-  callFun("navigateToFile", file, as.integer(line), as.integer(column))
+navigateToFile <- function(file = character(0), line = -1L, column = -1L, moveCursor = TRUE) {
+  callFun("navigateToFile", file, as.integer(line), as.integer(column), as.logical(moveCursor))
 }
 
 #' @export

--- a/man/navigateToFile.Rd
+++ b/man/navigateToFile.Rd
@@ -10,13 +10,14 @@ Open a file in RStudio, optionally at a specified location.
 The \code{navigateToFile} function was added in version 0.99.719 of RStudio.
 }
 \usage{
-navigateToFile(file, line = -1L, column = -1L)
+navigateToFile(file, line = -1L, column = -1L, moveCursor = TRUE)
 }
 
 \arguments{
   \item{file}{Optional; Path to the file to open)}
   \item{line}{Optional; integer specifying the line number on which to place the cursor}
   \item{column}{Optional; integer specifying the column number on which to place the cursor}
+  \item{moveCursor}{Optional; boolean specifying whether the cursor should move to the specified position}
 }
 
 \details{
@@ -25,7 +26,7 @@ The \code{navigateToFile} opens a file in RStudio. If the file is already open, 
 Once the file is open, the cursor is moved to the specified location. If the \code{file}
 argument is empty (the default), then the file is the file currently in view if one exists.
 If the \code{line} and \code{column} arguments are both equal to \code{-1L} (the default), then
-the cursor position in the document that is opened will be preserved.
+the cursor position in the document that is opened will be preserved. Alternatively, \code{moveCursor} can be set to FALSE to preserve the cursor position.
 
 Note that if your intent is to navigate to a particular function within a file, you can also cause RStudio to navigate there by invoking \code{\link[utils]{View}} on the function, which has the advantage of falling back on deparsing if the file is not available.
 }


### PR DESCRIPTION
This PR adds a boolean `moveCursor` to `navigateToFile`. The default value is TRUE which moves the cursor to the specified and line and column of the file if one is specified. If `moveCursor = false` is specified, then the call will scroll to the line and column so they are visible, but not move the users cursor. 