### PR TITLE
fix #188 NULL arguments in callRemote

### DIFF
--- a/R/remote.R
+++ b/R/remote.R
@@ -19,20 +19,17 @@ callRemote <- function(call, frame) {
   attr(call, "srcref") <- NULL
 
   # ensure rstudioapi functions get appropriate prefix
-  if (is.name(call[[1L]]))
-    call[[1L]] <- call("::", as.name("rstudioapi"), call[[1L]])
-
-  # ensure arguments are evaluated before sending request
-  call <- as.list(call)
-  for (i in seq_along(call)[-1L]) {
-    res <- eval(call[[i]], frame)
-    if (is.null(res)) {
-      call[i] <- list(NULL)
-    } else {
-      call[[i]] <- res
-    }
+  if (is.name(call[[1L]])) {
+    call_fun <- call("::", as.name("rstudioapi"), call[[1L]])
+  } else {
+    call_fun <- call[[1L]]
   }
-  call <- as.call(call)
+  
+  # ensure arguments are evaluated before sending request
+  call[[1L]] <- as.name("list")
+  args <- eval(call, envir = frame)
+  
+  call <- as.call(c(call_fun, args))
 
   # write to tempfile and rename, to ensure atomicity
   data <- list(secret = secret, call = call)

--- a/R/remote.R
+++ b/R/remote.R
@@ -23,8 +23,16 @@ callRemote <- function(call, frame) {
     call[[1L]] <- call("::", as.name("rstudioapi"), call[[1L]])
 
   # ensure arguments are evaluated before sending request
-  for (i in seq_along(call)[-1L])
-    call[[i]] <- eval(call[[i]], envir = frame)
+  call <- as.list(call)
+  for (i in seq_along(call)[-1L]) {
+    res <- eval(call[[i]], frame)
+    if (is.null(res)) {
+      call[i] <- list(NULL)
+    } else {
+      call[[i]] <- res
+    }
+  }
+  call <- as.call(call)
 
   # write to tempfile and rename, to ensure atomicity
   data <- list(secret = secret, call = call)


### PR DESCRIPTION
Unfortunately, a "NULL" call object can't be easily created, so we round-trip via a list to insert NULLs at appropriate positions.