### PR TITLE
Update documentation for chunk calls

### DIFF
--- a/R/chunk.R
+++ b/R/chunk.R
@@ -1,11 +1,14 @@
 #' Register Chunk Callback
 #'
 #' Registers a callback function to be executed after a chunk within an R Markdown document is run.
+#' Only one callback can be registered at a time, \code{\link{unregisterChunkCallback}} must be called to 
+#' unregister the callback between registrations.
 #'
-#' @param callback A callback function that returns a list of html output to be
-#' displayed after a chunk is executed. The callback will be passed two parameters; `chunkName` (referring to the chunk label) and `chunkCode` (the code within the chunk).
+#' @param callback A callback function that returns a named list containing html output in the
+#' member 'html' to be displayed after a chunk is executed. The callback will be passed two
+#' parameters; `chunkName` (referring to the chunk label) and `chunkCode` (the code within the chunk).
 #' @return A handle that can be used to unregister the chunk.
-#' @seealso \code{\link{registerChunkCallback}}
+#' @seealso \code{\link{unregisterChunkCallback}}
 #' @export
 registerChunkCallback <- function(callback)
 {
@@ -16,7 +19,8 @@ registerChunkCallback <- function(callback)
 #'
 #' Unregister a chunk callback previously registered via `registerChunkCallback()`.
 #'
-#' @param id A handle, as returned via a previous call to [registerChunkCallback].
+#' @param id A handle, as returned via a previous call to [registerChunkCallback]
+#'  or do not include to unregister current callback.
 #' @seealso \code{\link{registerChunkCallback}}
 #' @export
 unregisterChunkCallback <- function(id = NULL)


### PR DESCRIPTION
Make the `id` parameter optional for `unregisterChunkCallback` and update the documentation to reflect that. As is, the `id` or handle parameter is unnecessary as there can only be one callback registered at a time. I'm leaving that code there in case we allow for multiple callbacks in the future.

Relates to this issue: https://github.com/rstudio/rstudio/pull/7693