### PR TITLE
Change nomenclature to WYSIWYM

### DIFF
--- a/vignettes/visual-mode.Rmd
+++ b/vignettes/visual-mode.Rmd
@@ -19,7 +19,7 @@ library(rstudioapi)
 ```
 
 
-RStudio v1.4 includes a new [visual editing mode](https://rstudio.github.io/visual-markdown-editing/#/), which provides a [WYSIWYG](https://en.wikipedia.org/wiki/WYSIWYG)-style editing interface for R Markdown documents. This vignette describes how `rstudioapi` can be used to interface with the RStudio visual mode editor.
+RStudio v1.4 includes a new [visual editing mode](https://rstudio.github.io/visual-markdown-editing/#/), which provides a [WYSIWYM](https://en.wikipedia.org/wiki/WYSIWYM)-style editing interface for R Markdown documents. This vignette describes how `rstudioapi` can be used to interface with the RStudio visual mode editor.
 
 Most of the pre-existing `rstudioapi` functions used for interacting with a document (e.g. `rstudioapi::getSourceEditorContext()`) consume and / or produce objects which describe the position of the current selection in terms of row + column offsets into the document. Unfortunately, this abstraction does not neatly map into visual editing mode, as there is no notion of a "global" cursor position -- rather, a cursor might be placed into a particular cell, and could have an offset somewhere into that cell. 
 


### PR DESCRIPTION
The editor is "What you see is what you mean" (rather than "get") since it's only editing semantics not final document appearance.