### PR TITLE
add `sendToConsole(animate = TRUE)`

### DIFF
--- a/R/stubs.R
+++ b/R/stubs.R
@@ -343,7 +343,7 @@ savePlotAsImage <- function(file,
 #' 
 #' @param focus Boolean; focus the console after sending code?
 #' 
-#' @param animate Boolean; should the code be animated as if someone was typing it ?
+#' @param animate Boolean; should the submitted code be animated, as if someone was typing it?
 #' 
 #' @note The \code{sendToConsole} function was added in version 0.99.787 of
 #'   RStudio.

--- a/R/stubs.R
+++ b/R/stubs.R
@@ -343,6 +343,8 @@ savePlotAsImage <- function(file,
 #' 
 #' @param focus Boolean; focus the console after sending code?
 #' 
+#' @param animate Boolean; should the code be animated as if someone was typing it ?
+#' 
 #' @note The \code{sendToConsole} function was added in version 0.99.787 of
 #'   RStudio.
 #' 
@@ -354,12 +356,13 @@ savePlotAsImage <- function(file,
 #' 
 #' 
 #' @export
-sendToConsole <- function(code, execute = TRUE, echo = TRUE, focus = TRUE) {
+sendToConsole <- function(code, execute = TRUE, echo = TRUE, focus = TRUE, animate = FALSE) {
   callFun("sendToConsole",
           code = code,
           echo = echo,
           execute = execute,
-          focus = focus)
+          focus = focus, 
+          animate = animate)
 }
 
 #' Persistent keys and values

--- a/man/sendToConsole.Rd
+++ b/man/sendToConsole.Rd
@@ -4,7 +4,7 @@
 \alias{sendToConsole}
 \title{Send code to the R console}
 \usage{
-sendToConsole(code, execute = TRUE, echo = TRUE, focus = TRUE)
+sendToConsole(code, execute = TRUE, echo = TRUE, focus = TRUE, animate = FALSE)
 }
 \arguments{
 \item{code}{The \R code to be executed, as a character vector.}
@@ -15,6 +15,8 @@ into the console?}
 \item{echo}{Boolean; echo the code in the console as it is executed?}
 
 \item{focus}{Boolean; focus the console after sending code?}
+
+\item{animate}{Boolean; should the code be animated as if someone was typing it ?}
 }
 \description{
 Send code to the R console, and optionally execute it.


### PR DESCRIPTION
related to https://github.com/rstudio/rstudio/pull/10366

Should the function have some logic to complain if the underlying `.rs.api.sendToConsole()` does not have the argument yet ?