### PR TITLE
Robust to NULL osVersion

### DIFF
--- a/R/bug-report.R
+++ b/R/bug-report.R
@@ -23,6 +23,7 @@ bugReport <- function() {
   rVersion <- rInfo$R.version$version.string
   rVersion <- sub("^R version", "", rVersion, fixed = TRUE)
   osVersion <- rInfo$running
+  if (is.null(osVersion)) osVersion <- "<undetermined osVersion>"
 
   templateFile <- system.file("resources/bug-report.md", package = "rstudioapi")
   template <- readLines(templateFile)


### PR DESCRIPTION
Per `?osVersion`, it is documented to sometimes be `NULL`. That would break `renderTemplate()`.