### PR TITLE
add showEditSuggestion to pkgdown reference index

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -51,6 +51,7 @@ reference:
     - setCursorPosition
     - setSelectionRanges
     - setGhostText
+    - showEditSuggestion
 
     - documentSave
     - documentSaveAll


### PR DESCRIPTION
The pkgdown CI build has been failing since `showEditSuggestion()` was added (5781390) without a corresponding entry in the `_pkgdown.yml` reference index:

```
! In _pkgdown.yml, 1 topic missing from index: "showEditSuggestion".
```

This adds it to the Documents section, alongside `setGhostText`. Verified locally with `pkgdown::check_pkgdown()` (no problems found).